### PR TITLE
Parameterize contact email

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default[:god][:contacts] = ['ops']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,7 @@ template "/etc/god/master.god" do
   owner "root"
   group "root"
   mode 0755
+  variables :contacts => node[:god][:contacts]
 end
 
 runit_service "god"

--- a/templates/default/master.god.erb
+++ b/templates/default/master.god.erb
@@ -13,8 +13,9 @@ God::Contacts::Email.server_settings = {
   :domain => "<%= node[:domain] %>",
 }
 
-God.contact(:email) do |c|
-  c.name = 'ops'
-  c.email = 'ops@<%= node[:domain] %>'
-end
-
+<% @contacts.each do |contact| %>
+  God.contact(:email) do |c|
+    c.name = '<%= contact %>'
+    c.email = '<%= [contact, node[:domain]].join('@') %>'
+  end
+<% end %>


### PR DESCRIPTION
Instead of only being able to use `ops@<domain>`, move the contact email into
an attribute array that can be overridden. `ops` is still the default.

I'm not an expert at chef, so if there is an easy way to override the contact email that would be a better solution. Just didn't want to fork the repo to set the contact email.
