### PR TITLE
* allow bypass of install step for those that provide their own god exec...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default['god']['bin']               = '/usr/bin/god'
 default['god']['init_style']        = 'runit'
+default['god']['install']           = true
 default['god']['email']['from']     = 'god@'+node[:domain].to_s
 default['god']['email']['contacts'] = [['dev', 'developers@'+node[:domain].to_s, 'developers']]
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,9 +17,11 @@
 # limitations under the License.
 #
 
-gem_package "god" do
-  action :install
-  gem_binary "/usr/bin/gem"
+if node['god']['install'] 
+  gem_package "god" do
+    action :install
+    gem_binary "/usr/bin/gem"
+  end
 end
 
 directory "/etc/god/conf.d" do


### PR DESCRIPTION
This change allows someone to suppress the install of god from rubygems, by override node['god']['install'] = false. 

It defaults to true (install from rubygems) to provide backwards compatibility with the cookbook. 

Why?
We provide our own god executable via a debian created using fpm (https://github.com/jordansissel/fpm).  
