### PR TITLE
Making gem binary optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['god']['bin']               = '/usr/bin/god'
+default['god']['gem_binary']        = nil
 default['god']['init_style']        = 'runit'
 default['god']['email']['from']     = 'god@'+node[:domain].to_s
 default['god']['email']['contacts'] = [['dev', 'developers@'+node[:domain].to_s, 'developers']]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 gem_package "god" do
   action :install
-  gem_binary "/usr/bin/gem"
+  gem_binary node['god']['gem_binary'] if node['god']['gem_binary']
 end
 
 directory "/etc/god/conf.d" do


### PR DESCRIPTION
I see no reason why gem binary should be hardcoded. Its a good idea to make it optional, like in other
opscode cookbooks.
