### PR TITLE
Make rubygem binary path customizable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default['god']['email']['server']['server_auth'] = :plain
 default['god']['email']['server']['server_domain']   = ''
 default['god']['email']['server']['server_user']     = ''
 default['god']['email']['server']['server_password'] = ''
+default['ruby']['gem_binary'] = '/usr/bin/gem'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 gem_package "god" do
   action :install
-  gem_binary "/usr/bin/gem"
+  gem_binary node['ruby']['gem_binary']
 end
 
 directory "/etc/god/conf.d" do


### PR DESCRIPTION
I was unable to use this cookbook because my ruby gem executable is at `/usr/local/bin/gem`. This change allows users to customize the path.
